### PR TITLE
Current conf is preventing to accept ipv6 RA

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -134,12 +134,6 @@ then
      echo "fd42:$a:$b::" > /etc/yunohost/ula
 fi
 
-if [ ! -f /etc/sysctl.d/ipv6_forwarding.conf ];
-then
-    echo "net.ipv6.conf.all.forwarding = 1" > /etc/sysctl.d/ipv6_forwarding.conf
-    sysctl -p /etc/sysctl.d/ipv6_forwarding.conf
-fi
-
 # Interface
 if [ ! -f /etc/yunohost/interface ];
 then


### PR DESCRIPTION
    net.ipv6.conf.all.forwarding = 1

causes the host to ignore the routes pushed by router-announce (eg: radvd) on the LAN, which is the most common way to configure IPv6 on LANs.

That parameter caused my host to be unable to send any ipv6 packet => breaking ipv6 connectivity

(may be ported to stable/testing maybe, but I don't know your internal process :))